### PR TITLE
Include missing strings

### DIFF
--- a/packages/SystemUI/res/values/strings.xml
+++ b/packages/SystemUI/res/values/strings.xml
@@ -899,4 +899,24 @@
 
     <!-- Accessibility string for current zen mode and selected exit condition. A template that simply concatenates existing mode string and the current condition description. [CHAR LIMIT=20] -->
     <string name="zen_mode_and_condition"><xliff:g id="zen_mode" example="Priority interruptions only">%1$s</xliff:g>. <xliff:g id="exit_condition" example="For one hour">%2$s</xliff:g></string>
+
+    <!-- Screen pinning dialog title. -->
+    <string name="screen_pinning_title">Screen is pinned</string>
+    <!-- Screen pinning dialog description. -->
+    <string name="screen_pinning_description">This keeps it in view until you unpin. Touch and hold Back and Overview at the same time to unpin.</string>
+    <!-- Screen pinning dialog description when in accessibility mode. -->
+    <string name="screen_pinning_description_accessible">This keeps it in view until you unpin. Touch and hold Overview to unpin.</string>
+    <!-- Screen pinning positive response. -->
+    <string name="screen_pinning_positive">Got it</string>
+    <!-- Screen pinning negative response. -->
+    <string name="screen_pinning_negative">No thanks</string>
+
+    <!-- Hide quick settings tile confirmation title -->
+    <string name="quick_settings_reset_confirmation_title">Hide <xliff:g id="tile_label" example="Hotspot">%1$s</xliff:g>?</string>
+
+    <!-- Hide quick settings tile confirmation message -->
+    <string name="quick_settings_reset_confirmation_message">It will reappear the next time you turn it on in settings.</string>
+
+    <!-- Hide quick settings tile confirmation button -->
+    <string name="quick_settings_reset_confirmation_button">Hide</string>
 </resources>


### PR DESCRIPTION
Screen pinning was not properly working due to https://github.com/zephiK/android_frameworks_base/commit/5754949167b8897c661bd0d8c4b3d4d079c909b1 commit removing strings by accident. Add these strings back in to fix E/AndroidRuntime(11853): android.content.res.Resources: String resource ID #0x7f0c018e